### PR TITLE
Add GetSubjectLocation Function to Subject Model

### DIFF
--- a/PanoptesNetClient/PanoptesNetClient/Models/Subject.cs
+++ b/PanoptesNetClient/PanoptesNetClient/Models/Subject.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PanoptesNetClient.Models
 {
@@ -23,6 +25,18 @@ namespace PanoptesNetClient.Models
         public bool ShouldSerializeId()
         {
             return false;
+        }
+
+        public string GetSubjectLocation(int frame = 0)
+        {
+            string[] acceptedImages = { "image/jpeg", "image/png", "image/svg+xml", "image/gif" };
+
+            foreach (JProperty property in Locations[0])
+            {
+                if (acceptedImages.Contains(property.Name))
+                    return (string)property.Value;
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
In reviewing https://github.com/zooniverse/galaxy-zoo-touch-table/pull/6, it was decided this function should be moved to the subject model itself, so the function can be called upon the resource itself.