### PR TITLE
Do Not Use Constructor

### DIFF
--- a/PanoptesNetClient/PanoptesNetClient/Config.cs
+++ b/PanoptesNetClient/PanoptesNetClient/Config.cs
@@ -7,16 +7,8 @@ namespace PanoptesNetClient
 {
     static class Config
     {
-        public static string Host;
-        public static string ClientAppId;
-        public static string StatsHost;
-
-        static Config()
-        {
-            var appSettings = ConfigurationManager.AppSettings;
-            Host = appSettings["ApiHost"];
-            ClientAppId = appSettings["ApplicationId"];
-            StatsHost = appSettings["StatsHost"];
-        }
+        public static string Host = ConfigurationManager.AppSettings["ApiHost"];
+        public static string ClientAppId = ConfigurationManager.AppSettings["ApplicationId"];
+        public static string StatsHost = ConfigurationManager.AppSettings["StatsHost"];
     }
 }


### PR DESCRIPTION
Closes #7 

I noticed a bug in the touch table app while deploying that routes back to the client. Basically, the client relies on `Config.Host` to instantiate, but it is possible for the client to try to instantiate while `Config.Host` is still `null`. This bug should help fix the issue, along with another change I will introduce into touch table.