### PR TITLE
Update Classification Return

### DIFF
--- a/PanoptesNetClient/PanoptesNetClient/ApiClient.cs
+++ b/PanoptesNetClient/PanoptesNetClient/ApiClient.cs
@@ -100,23 +100,9 @@ namespace PanoptesNetClient
             StringContent content = new StringContent(jsonString, Encoding.UTF8, "application/json");
 
             HttpResponseMessage response = await Client.PostAsync(
-                $"{Config.Host}/pi/{type}", content);
+                $"{Config.Host}/api/{type}", content);
 
             return response;
-
-            //if (response.IsSuccessStatusCode)
-            //{
-            //    string data = await response.Content.ReadAsStringAsync();
-            //    List<T> result = ParseResponse<T>(data, type);
-            //    return result[0];
-            //} else
-            //{
-            //    var error = response.ReasonPhrase;
-            //    Console.WriteLine(
-            //        $"Error: {(int)response.StatusCode}: {error}"
-            //    );
-            //}
-            //return default(T);
         }
         #endregion
 

--- a/PanoptesNetClient/PanoptesNetClient/ApiClient.cs
+++ b/PanoptesNetClient/PanoptesNetClient/ApiClient.cs
@@ -89,7 +89,7 @@ namespace PanoptesNetClient
         /// Make a POST request. This should typically be for a new classification
         /// </summary>
         #region Generic Create
-        public async Task<T> Create<T>(T resource, string type) where T:IResource
+        public async Task<HttpResponseMessage> Create<T>(T resource, string type) where T:IResource
         {
             var dict = new Dictionary<string, IResource>
             {
@@ -100,21 +100,23 @@ namespace PanoptesNetClient
             StringContent content = new StringContent(jsonString, Encoding.UTF8, "application/json");
 
             HttpResponseMessage response = await Client.PostAsync(
-                $"{Config.Host}/api/{type}", content);
-            
-            if (response.IsSuccessStatusCode)
-            {
-                string data = await response.Content.ReadAsStringAsync();
-                List<T> result = ParseResponse<T>(data, type);
-                return result[0];
-            } else
-            {
-                string error = response.Content.ReadAsStringAsync().Result;
-                Console.WriteLine(
-                    $"Error: {error}"
-                );
-            }
-            return default(T);
+                $"{Config.Host}/pi/{type}", content);
+
+            return response;
+
+            //if (response.IsSuccessStatusCode)
+            //{
+            //    string data = await response.Content.ReadAsStringAsync();
+            //    List<T> result = ParseResponse<T>(data, type);
+            //    return result[0];
+            //} else
+            //{
+            //    var error = response.ReasonPhrase;
+            //    Console.WriteLine(
+            //        $"Error: {(int)response.StatusCode}: {error}"
+            //    );
+            //}
+            //return default(T);
         }
         #endregion
 

--- a/PanoptesNetClient/PanoptesNetClient/Clients/ClassificationClient.cs
+++ b/PanoptesNetClient/PanoptesNetClient/Clients/ClassificationClient.cs
@@ -1,6 +1,7 @@
 ﻿using PanoptesNetClient.Models;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PanoptesNetClient.Clients
@@ -24,7 +25,7 @@ namespace PanoptesNetClient.Clients
             return await GetList<Classification>(request);
         }
 
-        public async Task<Classification> Create(Classification classification)
+        public async Task<HttpResponseMessage> Create(Classification classification)
         {
             return await Create(classification, "classifications");
         }

--- a/PanoptesNetClient/PanoptesNetClient/Models/Classification.cs
+++ b/PanoptesNetClient/PanoptesNetClient/Models/Classification.cs
@@ -58,5 +58,8 @@ namespace PanoptesNetClient.Models
 
         [JsonProperty("workflow_version")]
         public string WorkflowVersion { get; set; }
+
+        [JsonProperty("utc_offset")]
+        public string UtcOffset { get; set; }
     }
 }

--- a/PanoptesNetClient/PanoptesNetClient/Models/Workflow.cs
+++ b/PanoptesNetClient/PanoptesNetClient/Models/Workflow.cs
@@ -12,7 +12,7 @@ namespace PanoptesNetClient.Models
         public string DisplayName { get; set; }
 
         [JsonProperty("tasks")]
-        public Dictionary<string, WorkflowTask> Tasks { get; set; }
+        public Dictionary<string, WorkflowTask> Tasks { get; set; } = new Dictionary<string, WorkflowTask>();
 
         [JsonProperty("classifications_count")]
         public int ClassificationsCount { get; set; }
@@ -50,7 +50,13 @@ namespace PanoptesNetClient.Models
         public string Type { get; set; }
 
         [JsonProperty("answers")]
-        public List<TaskAnswer> Answers {get;set;}
+        public List<TaskAnswer> Answers { get; set; } = new List<TaskAnswer>();
+
+        public WorkflowTask(string question, List<TaskAnswer> answers)
+        {
+            Answers = answers;
+            Question = question;
+        }
     }
 
     public class TaskAnswer
@@ -60,5 +66,11 @@ namespace PanoptesNetClient.Models
 
         [JsonProperty("next")]
         public string Next { get; set; }
+
+        public TaskAnswer(string label, string next = null)
+        {
+            Label = label;
+            Next = next;
+        }
     }
 }

--- a/PanoptesNetClient/PanoptesNetClient/PanoptesNetClient.nuspec
+++ b/PanoptesNetClient/PanoptesNetClient/PanoptesNetClient.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>1.1.1</version>
     <title>$title$</title>
     <authors>Zooniverse</authors>
     <owners>$author$</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/zooniverse/panoptes-net-client</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A .NET client for accessing the the Zooniverse Panoptes api.</description>
-    <releaseNotes>Initial release of the .NET client allowing GET and POST of resources.</releaseNotes>
+    <releaseNotes>Version 1.1.1 contains fixes to the config class used in client creation.</releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>client zooniverse panoptes</tags>
   </metadata>

--- a/PanoptesNetClient/PanoptesNetClientTests/ApiClientTests.cs
+++ b/PanoptesNetClient/PanoptesNetClientTests/ApiClientTests.cs
@@ -73,7 +73,7 @@ namespace PanoptesNetClientTests_NUnit
             Classification classification = new Classification();
             var result = await Client.Classifications.Create(classification, "classifications");
             Assert.That(result, Is.Not.Null);
-            Assert.IsInstanceOf<Classification>(result);
+            Assert.IsInstanceOf<HttpResponseMessage>(result);
         }
     }
 }


### PR DESCRIPTION
This change is a step towards getting the touch table into offline first mode and is necessary for the classification queue to work.

In order for the touch table to recognize when a submitted classification has failed, the client needs to return an `HttpResponseMessage` on classification submission (Create). The touch table may then determine what to do if it finds the response has a failing status code. 

A couple constructors are also added here for resources to make it easier to instantiate Panoptes resources with certain properties.